### PR TITLE
Add MadisonPHP 2016 to list

### DIFF
--- a/events.md
+++ b/events.md
@@ -3,6 +3,7 @@
 | SwanseaCon | Swansea, UK | 12th September 2016 | 13th September 2016 |
 | DrupalCon Europe | Dublin, Ireland | 26th September 2016 | 30th September 2016 |
 | PHP Craft | Johannesburg, South Africa | 28th September 2016 | 30th September 2016 |
+| MadisonPHP | Madison, WI, USA | 29th September 2016 | 30th September 2016 |
 | PHP NW | Manchester, UK | 1st October 2016 | 2nd October 2016 |
 | PHP Bulgaria | Sofia, Bulgaria | 7th October 2016 | 9th October 2016 |
 | Brno PHP | Brno, Czech Republic | 15th October 2016 | 15th October 2016 |


### PR DESCRIPTION
This adds an entry for the MadisonPHP conference, occuring end of September.
