### PR TITLE
Adding The PHP UK Conference

### DIFF
--- a/events.md
+++ b/events.md
@@ -13,3 +13,4 @@
 | php[world] | Washington D.C., USA | 14th November 2016 | 18th November 2016 |
 | PHP Brazil | Osasco, Brazil | 7th December 2016 | 11th December 2016 |
 | SunshinePHP | Miami, FL, USA | 2nd February 2017 | 4th February 2017 |
+| The PHP UK Conference | London, UK | 16th February 2017 | 17th February 2017 |


### PR DESCRIPTION
This adds a new entry for The PHP UK Conference in London on the 16th / 17th of February 2017
