### PR TITLE
Add ScotlandPHP conference

### DIFF
--- a/events.md
+++ b/events.md
@@ -9,6 +9,7 @@
 | PHP Bulgaria | Sofia, Bulgaria | 7th October 2016 | 9th October 2016 |
 | Brno PHP | Brno, Czech Republic | 15th October 2016 | 15th October 2016 |
 | ZendCon 2016 | Las Vegas, NV | 18th October 2016 | 21st October 2016 |
+| ScotlandPHP | Edinburgh, UK | 29th October 2016 | 29th October 2016 |
 | True North PHP | Toronto, Canada | 3rd November 2016 | 5th November 2016 |
 | php[world] | Washington D.C., USA | 14th November 2016 | 18th November 2016 |
 | PHP Brazil | Osasco, Brazil | 7th December 2016 | 11th December 2016 |


### PR DESCRIPTION
This adds a new entry for The ScotlandPHP Conference in Edinburgh on the 29th of October 2016
